### PR TITLE
Add a `:should-fire?` field to each interceptor

### DIFF
--- a/src/drop/app/main.cljs
+++ b/src/drop/app/main.cljs
@@ -10,20 +10,21 @@
             [slate.core :as sl]
             [slate.utils :as utils]))
 
-;; TODO: Copy (and maybe paste) rich text
-;; TODO: Find and replace
+;; PROG: don't fire ' autocomplete if char immediately before or after cursor is alphanumeric,
+;; TODO: Bug with char-at at last spot in paragraph.
+
 ;; TODO: Nav functions for moving between clauses, sentences, and paragraphs
 ;; TODO: cmd+shift+right, cmd+shift+left
 ;; TODO: when _only_ going up and down, support remembering the pixel offset where the up/down operation _began_, instead of
 ;;       just going up/down from the previous. The remembering should be cancelled if any other operation is performed, including
 ;;       navigation with left/right arrows, inserting text, etc. Ideally all logic for this should be _confined_ to the up/down (and possibly
 ;;       left/right) interceptors.
-;; TODO: don't fire ' autocomplete if char immediately before or after cursor is alphanumeric,
 ;; TODO: Investigate fonts that looks good _without_ kerning (Merriweather seems to do well)
 ;; TODO: Probably worth breaking out all of the history fns into a protocol and also implementing it for UIState
 ;; TODO: Make so that cmd+i, cmd+b, etc only get added to history when done with a range selection (how much do I care?)
 ;; TODO: Handle case of click, hold, type some stuff, THEN release
 ;; TODO: Make a React element that encapsulates the editor. This should live at the app level, not in Slate.
+;; TODO: Copy (and maybe paste) rich text
 ;; TODO: Set up Electron
 ;; TODO: File saving/loading
 ;; TODO: DOCX export/import
@@ -55,8 +56,7 @@
    (paragraph (uuid "p5") [(run "And this is paragraph número dos.")])])
 (def doc (document paragraphs))
 
-(def *ui-state (sl/init! :editor-state (editor-state doc (sel/selection :start [(uuid "p4") 0]
-                                                                        :end [(uuid "p4") 5]))
+(def *ui-state (sl/init! :editor-state (editor-state doc (sel/selection [(uuid "p3") 179]))
                          :dom-elem fake-editor
                          :hidden-input hidden-input))
 

--- a/src/slate/default_interceptors.cljs
+++ b/src/slate/default_interceptors.cljs
@@ -151,7 +151,14 @@
   (es/auto-surround editor-state \"))
 
 (definterceptor auto-surround-single-quote
-  {:add-to-history-immediately? true}
+  {:add-to-history-immediately? true
+   :should-fire? (fn [{:keys [selection] :as editor-state}]
+                   ;; Fire if the selection is a range or if it is a single
+                   ;; selection with a non-blank character before and after it.
+                   (or (sel/range? selection)
+                       (and (not (nav/content? (m/char-before editor-state)))
+                            (or (= (sel/caret selection) (m/len (es/current-paragraph editor-state)))
+                                (not (nav/word? (m/char-at editor-state)))))))}
   [editor-state _ui-state _e]
   (es/auto-surround editor-state \'))
 

--- a/src/slate/interceptors.clj
+++ b/src/slate/interceptors.clj
@@ -27,11 +27,15 @@
    will just be called as a normal function, **which is passed the EditorUIState atom** (not just it's contents) and the event. This exists because
    it is occasionally useful to hook into the interceptor system to execute operations that have nothing to do with Slate's editor surface
    itself, such as file-saving on a shortcut, or the undo and redo operations, which behave a little differently than the normal interceptor
-   paths."
-  [{:keys [input-name include-in-history? add-to-history-immediately? manual?]
+   paths.
+
+   `:should-fire?`: **Default `(constantly true)`**. A predicate which takes the current editor-state and returns true if the interceptor
+   should fire, false otherwise."
+  [{:keys [input-name include-in-history? add-to-history-immediately? manual? should-fire?]
     :or {include-in-history? true
          add-to-history-immediately? false
-         manual? false}}
+         manual? false
+         should-fire? '(constantly true)}}
    arglist, & fn-body]
   (assert input-name "Input name is required for interceptor macro.")
   (when (not include-in-history?)
@@ -41,6 +45,7 @@
                       :manual? ~manual?
                       :include-in-history? ~include-in-history?
                       :add-to-history-immediately? ~add-to-history-immediately?
+                      :should-fire? ~should-fire?
                       :interceptor-fn (fn [~@arglist] ~@fn-body)}))
 
 ;; TODO: 

--- a/src/slate/interceptors.cljs
+++ b/src/slate/interceptors.cljs
@@ -9,6 +9,7 @@
 ;; An Interceptor is a a function of (EditorState, EditorUiState?, Event?) -> EditorUpdate
 (defrecord Interceptor [interceptor-fn
                         input-name
+                        should-fire?
                         include-in-history?
                         add-to-history-immediately?
                         manual?]

--- a/src/slate/model/doc.cljs
+++ b/src/slate/model/doc.cljs
@@ -322,8 +322,8 @@
 ;; TODO: should the functions be inlined here?
 (extend-type Document
   Selectable
-  (char-at [doc sel] (char-at ((:children doc) (sel/start-para sel)) sel))
-  (char-before [doc sel] (char-before ((:children doc) (sel/start-para sel)) sel))
+  (char-at [doc sel] (char-at ((:children doc) (sel/caret-para sel)) sel))
+  (char-before [doc sel] (char-before ((:children doc) (sel/caret-para sel)) sel))
   (selected-content [doc sel] (doc-selected-content doc sel)) ; TODO: how to handle UUIDs with this?
   (formatting [doc sel] (doc-formatting doc sel))
 

--- a/src/slate/model/editor_state.cljs
+++ b/src/slate/model/editor_state.cljs
@@ -234,6 +234,12 @@
     (->EditorUpdate (editor-state new-doc new-selection)
                     (changelist :changed-uuids #{uuid}))))
 
+(defn current-paragraph
+  "Returns current paragraph if selection is a single selection."
+  [{:keys [selection doc]}]
+  {:pre [(sel/single? selection)]}
+  (get (:children doc) (sel/caret-para selection)))
+
 ;; TODO: Auto-set :formats on selection
 (defn set-selection
   "Returns a new EditorUpdate with the selection set to `new-selection`."
@@ -330,10 +336,10 @@
 
   ;; TODO: any point in implementing this for EditorState (keep in mind: YAGNI)
   m/Selectable
-  ;; (char-at [{:keys [doc selection]}]
-  ;;   (char-at doc selection))
-  ;; (char-before [{:keys [doc selection]}]
-  ;;   (char-before doc selection))
+  (char-at [{:keys [doc selection]}]
+    (m/char-at doc selection))
+  (char-before [{:keys [doc selection]}]
+    (m/char-before doc selection))
   (selected-content [{:keys [doc selection]}]
     (m/selected-content doc selection))
   ;; (formatting [{:keys [doc selection]}]

--- a/src/slate/model/navigation.cljs
+++ b/src/slate/model/navigation.cljs
@@ -47,6 +47,13 @@
     true
     false))
 
+(defn content?
+  "Is argument a content char?"
+  [char]
+  (and (not (whitespace? char))
+       (not= "" char)
+       (not= nil char)))
+
 (defn word?
   "Is argument a word char?"
   [char]

--- a/src/slate/model/paragraph.cljs
+++ b/src/slate/model/paragraph.cljs
@@ -262,9 +262,11 @@
 (extend-type Paragraph
   Selectable
   (char-at [para sel]
-    (let [[run-idx run-offset] (at-offset (:runs para) (sel/caret sel))
-          run-text (:text ((:runs para) run-idx))]
-      (nth run-text run-offset)))
+    (if (>= (sel/caret sel) (len para))
+      "" #_(throw (js/Error. "char-at given offset >= length of paragraph"))
+      (let [[run-idx run-offset] (at-offset (:runs para) (sel/caret sel))
+            run-text (:text ((:runs para) run-idx))]
+        (nth run-text run-offset))))
 
   (char-before [para sel]
     (if (zero? (sel/caret sel))

--- a/test/slate/model/document_test.cljs
+++ b/test/slate/model/document_test.cljs
@@ -338,14 +338,16 @@
     (is (= "f" (sl/char-at doc (selection ["p1" 0]))))
     (is (= "o" (sl/char-at doc (selection ["p1" 1]))))
     (is (= "z" (sl/char-at doc (selection ["p1" 13]))))
-    (is (thrown? js/Error (sl/char-at doc (selection ["p1" 14])))))
+    (is (= "" (sl/char-at doc (selection ["p1" 14]))))
+    #_(is (thrown? js/Error (sl/char-at doc (selection ["p1" 14])))))
 
   (testing "works in other paragraphs"
     (is (= "a" (sl/char-at doc (selection ["p2" 0]))))
     (is (= "b" (sl/char-at doc (selection ["p2" 3]))))
     (is (= "c" (sl/char-at doc (selection ["p2" 7]))))
     (is (= "d" (sl/char-at doc (selection ["p2" 11]))))
-    (is (thrown? js/Error (sl/char-at doc (selection ["p2" 12]))))))
+    (is (= "" (sl/char-at doc (selection ["p2" 12]))))
+    #_(is (thrown? js/Error (sl/char-at doc (selection ["p2" 12]))))))
 
 (deftest char-before-test
   (testing "works in 1st paragraph"

--- a/test/slate/model/paragraph_test.cljs
+++ b/test/slate/model/paragraph_test.cljs
@@ -260,7 +260,8 @@
     (is (= "f" (sl/char-at mypara (selection ["123" 0]))))
     (is (= "o" (sl/char-at mypara (selection ["123" 1]))))
     (is (= "o" (sl/char-at mypara (selection ["123" 2]))))
-    (is (thrown? js/Error (sl/char-at mypara (selection ["123" 3]))))))
+    (is (= "" (sl/char-at mypara (selection ["123" 3]))))
+    #_(is (thrown? js/Error (sl/char-at mypara (selection ["123" 3]))))))
 
 (deftest char-before-test
   (let [mypara (paragraph "123" [(run "foo")])]
@@ -268,4 +269,5 @@
     (is (= "f" (sl/char-before mypara (selection ["123" 1]))))
     (is (= "o" (sl/char-before mypara (selection ["123" 2]))))
     (is (= "o" (sl/char-before mypara (selection ["123" 3]))))
-    (is (thrown? js/Error (sl/char-before mypara (selection ["123" 4]))))))
+    (is (= "" (sl/char-before mypara (selection ["123" 4]))))
+    #_(is (thrown? js/Error (sl/char-before mypara (selection ["123" 4]))))))


### PR DESCRIPTION
Only fire ' auto-close interceptor for a single selection when there
isn't a content char immediately before or after the cursor.